### PR TITLE
Use modern v8 APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "compress-buffer-crc32",
   "description": "Synchronous Buffer compression library for Node.js",
-  "homepage" : "http://egorfine.github.com/node-compress-buffer",
-  "bugs" : { "url" : "http://github.com/egorFiNE/node-compress-buffer/issues" },
-  "version": "2.0.1",
+  "homepage": "http://egorfine.github.com/node-compress-buffer",
+  "bugs": {
+    "url": "http://github.com/egorFiNE/node-compress-buffer/issues"
+  },
+  "version": "3.0.0",
   "author": "Egor Egorov",
   "repository": {
     "type": "git",
     "url": "http://github.com/egorfine/node-compress-buffer.git"
   },
-  "main" : "./index",
+  "main": "./index",
   "devDependencies": {
     "nodeunit": ">=0.5.4"
   },

--- a/src/compress-buffer.cc
+++ b/src/compress-buffer.cc
@@ -220,7 +220,7 @@ namespace node_compress_buffer {
         v8::Local<v8::Value> bufferIn = info[0];
 
         if (info.Length() > 1) {
-            compressionLevel = info[1]->IntegerValue();
+            compressionLevel = info[1]->IntegerValue(Nan::GetCurrentContext()).FromJust();
         }
 
         size_t bytesIn = node::Buffer::Length(bufferIn);
@@ -259,23 +259,23 @@ namespace node_compress_buffer {
 
         v8::Local<v8::Object> result = Nan::New<v8::Object>();
 
-        result->Set(Nan::New(SYM_BODY), Nan::CopyBuffer(dataOut, bytesOut).ToLocalChecked());
+        result->Set(Nan::GetCurrentContext(), Nan::New(SYM_BODY), Nan::CopyBuffer(dataOut, bytesOut).ToLocalChecked());
 
-        result->Set(Nan::New(SYM_BOUNDARY), Nan::CopyBuffer(dataBoundary, bytesBoundary).ToLocalChecked());
+        result->Set(Nan::GetCurrentContext(), Nan::New(SYM_BOUNDARY), Nan::CopyBuffer(dataBoundary, bytesBoundary).ToLocalChecked());
 
         v8::Local<v8::Object> dataOffsets = Nan::New<v8::Object>();
-        dataOffsets->Set(Nan::New(SYM_LEFT), Nan::New<v8::Integer>(HEADER_SIZE));
-        dataOffsets->Set(Nan::New(SYM_RIGHT), Nan::New<v8::Integer>(HEADER_SIZE + dataLength));
-        dataOffsets->Set(Nan::New(SYM_LAST_BLOCK), Nan::New<v8::Integer>(lastBlockPosition));
+        dataOffsets->Set(Nan::GetCurrentContext(), Nan::New(SYM_LEFT), Nan::New<v8::Integer>(HEADER_SIZE));
+        dataOffsets->Set(Nan::GetCurrentContext(), Nan::New(SYM_RIGHT), Nan::New<v8::Integer>(HEADER_SIZE + dataLength));
+        dataOffsets->Set(Nan::GetCurrentContext(), Nan::New(SYM_LAST_BLOCK), Nan::New<v8::Integer>(lastBlockPosition));
 
         v8::Local<v8::Object> meta = Nan::New<v8::Object>();
-        meta->Set(Nan::New(SYM_OFFSETS), dataOffsets);
-        meta->Set(Nan::New(SYM_LENGTH), Nan::New<v8::Integer>(static_cast<uint32_t>(bytesIn)));
-        meta->Set(Nan::New(SYM_LAST_VALUE), Nan::New<v8::Integer>(lastBlockValue));
-        meta->Set(Nan::New(SYM_RAW_LENGTH), Nan::New<v8::Integer>(static_cast<uint32_t>(bytesOut - HEADER_SIZE - FOOTER_SIZE)));
-        meta->Set(Nan::New(SYM_CRC), Nan::CopyBuffer(dataOut + (bytesOut - FOOTER_SIZE), 4).ToLocalChecked());
+        meta->Set(Nan::GetCurrentContext(), Nan::New(SYM_OFFSETS), dataOffsets);
+        meta->Set(Nan::GetCurrentContext(), Nan::New(SYM_LENGTH), Nan::New<v8::Integer>(static_cast<uint32_t>(bytesIn)));
+        meta->Set(Nan::GetCurrentContext(), Nan::New(SYM_LAST_VALUE), Nan::New<v8::Integer>(lastBlockValue));
+        meta->Set(Nan::GetCurrentContext(), Nan::New(SYM_RAW_LENGTH), Nan::New<v8::Integer>(static_cast<uint32_t>(bytesOut - HEADER_SIZE - FOOTER_SIZE)));
+        meta->Set(Nan::GetCurrentContext(), Nan::New(SYM_CRC), Nan::CopyBuffer(dataOut + (bytesOut - FOOTER_SIZE), 4).ToLocalChecked());
 
-        result->Set(Nan::New(SYM_META), meta);
+        result->Set(Nan::GetCurrentContext(), Nan::New(SYM_META), meta);
 
         free(dataOut);
         free(dataBoundary);
@@ -298,10 +298,10 @@ namespace node_compress_buffer {
             return;
         }
 
-        v8::Local<v8::Object> bufferIn = info[0]->ToObject();
+        v8::Local<v8::Object> bufferIn = info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
         if (info.Length() > 1) {
-            compressionLevel = info[1]->IntegerValue();
+            compressionLevel = info[1]->IntegerValue(Nan::GetCurrentContext()).FromJust();
         }
 
         const char *dataIn = node::Buffer::Data(bufferIn);
@@ -320,7 +320,7 @@ namespace node_compress_buffer {
             return;
         }
 
-        v8::Handle<v8::Value> b = Nan::CopyBuffer(dataOut, bytesOut).ToLocalChecked();
+        v8::Local<v8::Value> b = Nan::CopyBuffer(dataOut, bytesOut).ToLocalChecked();
         free(dataOut);
         info.GetReturnValue().Set(b);
     }
@@ -332,9 +332,9 @@ namespace node_compress_buffer {
         int sum = HEADER_SIZE + FOOTER_SIZE + ((l - 1) * SPACER_SIZE);
 
         for(; i < l; i++) {
-            v8::Local<v8::Object> obj = arr->Get(i)->ToObject();
+            v8::Local<v8::Object> obj = arr->Get(Nan::GetCurrentContext(), i).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
-            if (!obj->Has(Nan::New(SYM_META))) {
+            if (!obj->Has(Nan::GetCurrentContext(), Nan::New(SYM_META)).FromJust()) {
                 char msg[40];
                 sprintf(msg, "ESTIMATE wrong object (no meta key) at: %d", i);
                 Nan::ThrowError(msg);
@@ -342,9 +342,9 @@ namespace node_compress_buffer {
                 return;
             }
 
-            v8::Local<v8::Object> meta = obj->Get(Nan::New(SYM_META))->ToObject();
+            v8::Local<v8::Object> meta = obj->Get(Nan::GetCurrentContext(), Nan::New(SYM_META)).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
-            if (!meta->Has(Nan::New(SYM_RAW_LENGTH))) {
+            if (!meta->Has(Nan::GetCurrentContext(), Nan::New(SYM_RAW_LENGTH)).FromJust()) {
                 char msg[60];
                 sprintf(msg, "ESTIMATE wrong object (no rawLength key) at: %d", i);
                 Nan::ThrowError(msg);
@@ -352,7 +352,7 @@ namespace node_compress_buffer {
                 return;
             }
 
-            sum += meta->Get(Nan::New(SYM_RAW_LENGTH))->Uint32Value();
+            sum += meta->Get(Nan::GetCurrentContext(), Nan::New(SYM_RAW_LENGTH)).ToLocalChecked()->Uint32Value(Nan::GetCurrentContext()).FromJust();
         }
 
         info.GetReturnValue().Set(Nan::New<v8::Integer>(sum));
@@ -380,9 +380,9 @@ namespace node_compress_buffer {
         int i = 0;
 
         for (; i < l; i++) {
-            v8::Local<v8::Object> obj = arr->Get(i)->ToObject();
+            v8::Local<v8::Object> obj = arr->Get(Nan::GetCurrentContext(), i).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
-            if (!obj->Has(Nan::New(SYM_META))) {
+            if (!obj->Has(Nan::GetCurrentContext(), Nan::New(SYM_META)).FromJust()) {
                 char msg[40];
                 sprintf(msg, "CRC32 wrong object (no meta key) at: %d", i);
                 Nan::ThrowError(msg);
@@ -390,9 +390,9 @@ namespace node_compress_buffer {
                 return;
             }
 
-            v8::Local<v8::Object> meta = obj->Get(Nan::New(SYM_META))->ToObject();
+            v8::Local<v8::Object> meta = obj->Get(Nan::GetCurrentContext(), Nan::New(SYM_META)).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
-            if (!meta->Has(Nan::New(SYM_CRC))) {
+            if (!meta->Has(Nan::GetCurrentContext(), Nan::New(SYM_CRC)).FromJust()) {
                 char msg[40];
                 sprintf(msg, "CRC32 wrong object (no crc key) at: %d", i);
                 Nan::ThrowError(msg);
@@ -400,7 +400,7 @@ namespace node_compress_buffer {
                 return;
             }
 
-            v8::Local<v8::Value> objCrc = meta->Get(Nan::New(SYM_CRC));
+            v8::Local<v8::Value> objCrc = meta->Get(Nan::GetCurrentContext(), Nan::New(SYM_CRC)).ToLocalChecked();
             if (!node::Buffer::HasInstance(objCrc)) {
                 char msg[40];
                 sprintf(msg, "CRC32 is not a buffer at: %d", i);
@@ -409,7 +409,7 @@ namespace node_compress_buffer {
                 return;
             }
 
-            v8::Local<v8::Object> bufCrc = objCrc->ToObject();
+            v8::Local<v8::Object> bufCrc = objCrc->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
             if (node::Buffer::Length(bufCrc) != 4) {
                 char msg[40];
@@ -420,15 +420,15 @@ namespace node_compress_buffer {
             }
 
             unsigned long tmpCrc = reverseBytes((unsigned char *) node::Buffer::Data(bufCrc));
-            unsigned long tmpLen = meta->Get(Nan::New(SYM_LENGTH))->Uint32Value();
+            unsigned long tmpLen = meta->Get(Nan::GetCurrentContext(), Nan::New(SYM_LENGTH)).ToLocalChecked()->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
             crc = crc32_combine(crc, tmpCrc, tmpLen);
             tot += tmpLen;
         }
 
         v8::Local<v8::Object> data = Nan::New<v8::Object>();
-        data->Set(Nan::New(SYM_CRC), Nan::CopyBuffer((char *) &crc, 4).ToLocalChecked());
-        data->Set(Nan::New(SYM_LENGTH), Nan::CopyBuffer((char *) &tot, 4).ToLocalChecked());
+        data->Set(Nan::GetCurrentContext(), Nan::New(SYM_CRC), Nan::CopyBuffer((char *) &crc, 4).ToLocalChecked());
+        data->Set(Nan::GetCurrentContext(), Nan::New(SYM_LENGTH), Nan::CopyBuffer((char *) &tot, 4).ToLocalChecked());
 
         info.GetReturnValue().Set(data);
     }
@@ -462,7 +462,7 @@ namespace node_compress_buffer {
             return;
         }
 
-        v8::Local<v8::Object> bufferIn = info[0]->ToObject();
+        v8::Local<v8::Object> bufferIn = info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
         strmUncompress.next_in = (Bytef*) node::Buffer::Data(bufferIn);
         strmUncompress.avail_in = node::Buffer::Length(bufferIn);
@@ -517,21 +517,21 @@ namespace node_compress_buffer {
             return;
         }
 
-        v8::Handle<v8::Value> b = Nan::CopyBuffer((char *)bufferOut, malloc_size).ToLocalChecked();
+        v8::Local<v8::Value> b = Nan::CopyBuffer((char *)bufferOut, malloc_size).ToLocalChecked();
         free(bufferOut);
         info.GetReturnValue().Set(b);
     }
 
-    void init(v8::Handle<v8::Object> target) {
+    void init(v8::Local<v8::Object> target) {
 
         tmpBody = (unsigned char *) malloc(CHUNK);
 
         const unsigned char header[] = {0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff};
 
-        v8::Handle<v8::Object> buffers = Nan::New<v8::Object>();
-        buffers->Set(Nan::New(SYM_HEADER), Nan::CopyBuffer(reinterpret_cast<const char*>(header), 10).ToLocalChecked());
+        v8::Local<v8::Object> buffers = Nan::New<v8::Object>();
+        buffers->Set(Nan::GetCurrentContext(), Nan::New(SYM_HEADER), Nan::CopyBuffer(reinterpret_cast<const char*>(header), 10).ToLocalChecked());
 
-        target->Set(Nan::New(SYM_BUFFERS), buffers);
+        target->Set(Nan::GetCurrentContext(), Nan::New(SYM_BUFFERS), buffers);
 
         Nan::SetMethod(target, "compress", compress);
         Nan::SetMethod(target, "uncompress", uncompress);

--- a/test/node-compress-buffer-test.js
+++ b/test/node-compress-buffer-test.js
@@ -14,7 +14,7 @@ var loremIpsum="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 
 exports['basic compress']= function(test) {
 	test.expect(2);
-	var uncompressed = new Buffer(loremIpsum);
+	var uncompressed = Buffer.from(loremIpsum);
 	var compressed = compress(uncompressed);
 	test.equal(compressed.length,282);
 	test.equal(md5(compressed), "6e31946d851b7cab51e058653a16b666");
@@ -23,7 +23,7 @@ exports['basic compress']= function(test) {
 
 exports['basic uncompress']= function(test) {
 	test.expect(2);
-	var uncompressed = new Buffer(loremIpsum);
+	var uncompressed = Buffer.from(loremIpsum);
 	var compressed = compress(uncompressed);
 	uncompressed = uncompress(compressed);
 	test.equal(uncompressed.length,loremIpsum.length);
@@ -60,7 +60,7 @@ exports['compress short']= function(test) {
 	test.expect(2);
 	var buffer, compressed;
 
-	buffer = new Buffer("too short");
+	buffer = Buffer.from("too short");
 	compressed = compress(buffer);
 	test.notEqual(compressed,buffer);
 	test.notEqual(compressed.length,buffer.length);
@@ -70,10 +70,10 @@ exports['compress short']= function(test) {
 
 exports['errors']= function(test) {
 	test.expect(2);
-	var compressed = compress(new Buffer(""));
+	var compressed = compress(Buffer.from(""));
 	test.ok(compressed.length>=0);
 	
-	var nothing = uncompress(new Buffer(" sfsdcfgdfgsdgfdsgdgdsgdfgsdfgsdfgdfgfsfd "));
+	var nothing = uncompress(Buffer.from(" sfsdcfgdfgsdgfdsgdgdsgdfgsdfgsdfgdfgfsfd "));
 	test.ok(nothing==null);
 	
 	test.done();


### PR DESCRIPTION
Stop using v8 APIs deprecated around engine version 4.3 and switch to modern equivalents.

```
node-compress-buffer-test
✔ basic compress
✔ basic uncompress
✔ compress with compression levels
✔ string exceptions
✔ compress short
✔ errors

OK: 11 assertions (11ms)
```

Tested on node v6.9, v8, v10, v12, but even earlier node version compatibility might be broken, hence new major version.